### PR TITLE
Add "Common Issues" section with details on using the correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ web-ext run --keep-profile-changes --firefox-profile=<profilename>
 ```
 
 Or you can use the VS Code "Debugger for Firefox" extension and the `.vscode/launch.json` file provided in this repo.
+
+## Common Issues
+
+### Install Successful, but Incorrect URL
+Did you successfully install the tool, but the blue banner still doesn't show?
+
+Schedule lookup can us a variety of subdomain URLs (e.g., #7 -- https://prodwebxe7-hv.rose-hulman.edu/regweb/). With the current version of this tool, it only works with https://prodwebxe-hv.rose-hulman.edu/regweb/. 
+
+To resolve this issue, delete any numbers after prodwebxe, which should use the correct URL. The banner should now be blue, indicating it's working. 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ Or you can use the VS Code "Debugger for Firefox" extension and the `.vscode/lau
 ### Install Successful, but Incorrect URL
 Did you successfully install the tool, but the blue banner still doesn't show?
 
-Schedule lookup can us a variety of subdomain URLs (e.g., #7 -- https://prodwebxe7-hv.rose-hulman.edu/regweb/). With the current version of this tool, it only works with https://prodwebxe-hv.rose-hulman.edu/regweb/. 
+Schedule lookup can use a variety of subdomain URLs (e.g., #7 -- https://prodwebxe7-hv.rose-hulman.edu/regweb/). In the current version of this tool, it only works with https://prodwebxe-hv.rose-hulman.edu/regweb/. 
 
-To resolve this issue, delete any numbers after prodwebxe, which should use the correct URL. The banner should now be blue, indicating it's working. 
+To resolve this issue, delete any numbers after prodwebxe, which will force it to use the correct URL. The banner should now be blue, indicating it's working. 


### PR DESCRIPTION
This is meant as a temporary fix for #3 by adding a section on "Common Issues" so people know to update the URL if there are issues with the banner not showing blue on install. 